### PR TITLE
Database Ticket Field Names Updated

### DIFF
--- a/database-ticket.html
+++ b/database-ticket.html
@@ -81,9 +81,12 @@ If there is not enough information for us to know what needs done without needin
                     </div>
                     <div id="ticket-reason">
                         <h2>Other Info</h2>
-                        Name of Agent who approved:
-                        <input id="agentName" type="text" placeholder="Name" />
-                        Reason for ticket:
+                        Name of Team Lead who approved:
+                        <input id="agentName" type="text" placeholder="Team Lead Name" />
+                        Reason for Approval:
+                        <p style="color: red; font-size: 12px;">
+                            This field should ONLY list the reason for the ticket being approved by a team lead.
+                        </p>
                         <textarea id="ticketReason" placeholder="Reason for Data Fix"></textarea>
                     </div>
                 </div>

--- a/js/database-ticket.js
+++ b/js/database-ticket.js
@@ -35,10 +35,10 @@ Shortcut Story Link:
 ${ticket_data.Shortcut_Story_Link}
 
 **Case Info**
-Approving Agent's Name:
+Approving Team Lead's Name:
 ${ticket_data.Approving_Agent_Name}
 
-Ticket Reason:
+Ticket Approval Reason:
 ${ticket_data.Ticket_Reason}
 
 **Fix Details**
@@ -67,10 +67,10 @@ Shortcut Story Link:<br>
 ${ticket_data.Shortcut_Story_Link}<br>
 <br>
 **Case Info**<br>
-Approving Agent's Name:<br>
+Approving Team Lead's Name:<br>
 ${ticket_data.Approving_Agent_Name}<br>
 <br>
-Ticket Reason:<br>
+Ticket Approval Reason:<br>
 ${ticket_data.Ticket_Reason}<br>
 <br>
 **Fix Details**<br>


### PR DESCRIPTION
There was some concern with users adding what they wanted done for the database fix in the "Ticket Reason" field. The field was updated to help better direct what the intention of the filed to provide why the database ticket was approved to request the fix.

Updates made:
Old Title  ----> New Title
Name of Agent who approved ----> Name of Team Lead who approved

Reason for ticket ----> Reason for Approval