### PR TITLE
added fields for store name and reporting rep name

### DIFF
--- a/src/Tools/bug-ticket/bug-ticket-v2.html
+++ b/src/Tools/bug-ticket/bug-ticket-v2.html
@@ -68,34 +68,46 @@
             </div>
             <div class="container content">
                 <div style="z-index: 1;" id="basic-content" data="1"  class="active">
-                        <div title="The CRM ID of the client you are submitting the ticket for." class="note-wrapper">
-                            CRM
-                            <span class="fa-solid fa-question"></span>
-                        </div>
-                        <input id="crm" type="text" placeholder="Enter a CRM" />
-                        <br>
-                        <div title="The part of the system affected by the bug." class="note-wrapper">
-                            System Area Affected
-                            <span class="fa-solid fa-question"></span>
-                        </div>
-                        <input id="systemArea" type="text" placeholder="Enter Part of the System Affected" />
-                        <br>
-                        <div title="Are you able to follow a set of steps to reproduce the bug consistently?" class="note-wrapper">
-                            Can you replicate this on a Test Site or Customers Site?
-                            <span class="fa-solid fa-question"></span>
-                        </div>
-                        <div choice-selector replicable-selector>
-                            <div replicable='yes'>Yes</div>
-                            <div replicable='no'>No</div>
-                        </div><br>
-                        <div title="If 'yes' to above select any below that apply." class="note-wrapper">
-                            Where were able to replicate the behavior?(If 'yes' to above select any below that apply)
-                            <span class="fa-solid fa-question"></span>
-                        </div>
-                        <div choice-selector where-selector>
-                            <div where='Test'>Test Site</div>
-                            <div where='Customer'>Customer Site</div>
-                        </div>
+                    <div title="The Support Rep submitting the ticket." class="note-wrapper">
+                        Support Tech Name
+                        <span class="fa-solid fa-question"></span>
+                    </div>
+                    <input id="Support-Rep" type="text" placeholder="Enter Support Rep" />
+                    <br>
+                    <div title="The name of the store you are submitting the ticket for." class="note-wrapper">
+                        Store Name
+                        <span class="fa-solid fa-question"></span>
+                    </div>
+                    <input id="Store-Name" type="text" placeholder="Enter Store Name" />
+                    <br>
+                    <div title="The CRM ID of the client you are submitting the ticket for." class="note-wrapper">
+                        CRM
+                        <span class="fa-solid fa-question"></span>
+                    </div>
+                    <input id="crm" type="text" placeholder="Enter a CRM" />
+                    <br>
+                    <div title="The part of the system affected by the bug." class="note-wrapper">
+                        System Area Affected
+                        <span class="fa-solid fa-question"></span>
+                    </div>
+                    <input id="systemArea" type="text" placeholder="Enter Part of the System Affected" />
+                    <br>
+                    <div title="Are you able to follow a set of steps to reproduce the bug consistently?" class="note-wrapper">
+                        Can you replicate this on a Test Site or Customers Site?
+                        <span class="fa-solid fa-question"></span>
+                    </div>
+                    <div choice-selector replicable-selector>
+                        <div replicable='yes'>Yes</div>
+                        <div replicable='no'>No</div>
+                    </div><br>
+                    <div title="If 'yes' to above select any below that apply." class="note-wrapper">
+                        Where were able to replicate the behavior?(If 'yes' to above select any below that apply)
+                        <span class="fa-solid fa-question"></span>
+                    </div>
+                    <div choice-selector where-selector>
+                        <div where='Test'>Test Site</div>
+                        <div where='Customer'>Customer Site</div>
+                    </div>
                 </div>
                 <div style="z-index: 2;" id="steps-content" data="2" class="in-active">
                     <h2 class="header-center">

--- a/src/Tools/bug-ticket/bug-ticket-v2.js
+++ b/src/Tools/bug-ticket/bug-ticket-v2.js
@@ -136,7 +136,13 @@ async function validateData(){
     let current_step = parseInt(document.querySelector('#info-tabs .active').getAttribute('step'));
     //compare current_step value against potential cases, complete the actions for any case that results as true
     switch (current_step) {
-        case 1://crm, system area, and is replicable (yes or no) check
+        case 1://Support Rep, Store Name, CRM, system area, and is replicable (yes or no) check
+            if(document.getElementById('Support-Rep').value === ''){
+                bad_object.list['SupportRep'] = 'Please enter the name of the Support Rep submitting the ticket.';
+            }
+            if(document.getElementById('Store-Name').value === ''){
+                bad_object.list['StoreName'] = 'Please enter the name of the store reporting an issue.';
+            }
             if(document.getElementById('crm').value === '' || !RegExp(/^(?:[c|C][r|R][m|M])?\d{2,}$/).test(document.getElementById('crm').value)){
                 bad_object.list['crm'] = 'The CRM needs to be a valid CRM.(2 digits or more)';
             }
@@ -283,6 +289,8 @@ function generateTicket(passed_object = {}){
         if (!Object.keys(passed_object).length) {
             //if the passed object has nothing in it, then data is set to be the below object
             data = {
+                supportRep: document.getElementById('Support-Rep').value,
+                storeName: document.getElementById('Store-Name').value,
                 crm: document.getElementById('crm').value,
                 area: document.getElementById('systemArea').value,
                 replicable: document.querySelector('[replicable].selected').getAttribute('replicable'),
@@ -320,9 +328,11 @@ function generateTicket(passed_object = {}){
         } else {
             //if passed_object has data in it, then data is set to the below object to use the old ticket data
             data = {
-                crm: passed_object.crm,
-                area: passed_object.area,
-                replicable: passed_object.replicable,
+                supportRep: passed_object.supportRep || '',
+                storeName: passed_object.storeName || '',
+                crm: passed_object.crm || '',
+                area: passed_object.area || '',
+                replicable: passed_object.replicable || '',
                 steps: () => {
                     //function that loops through the old ticket data steps and builds a string then returns the string value as it's resolution when called
                     let string = '';
@@ -371,6 +381,12 @@ function generateTicket(passed_object = {}){
     //this sets a string as the value of the textarea container when generating a ticket using the object values created from above '${}' formatting is in-line accessing for variable data.
     document.querySelector('#ticket-container > div > textarea').value = `**LOCATION:**
 **Bug Submission:**
+Reporting Tech:
+${data.supportRep}
+
+Store:
+${data.storeName}
+
 Store ID:
 ${data.crm}
 
@@ -531,6 +547,8 @@ function newCookieData(){
     }
     //creates a js object out of the current ticket data
     let bug_object = {
+        supportRep: scrubBadJsonChar(document.getElementById('Support-Rep').value),
+        storeName: scrubBadJsonChar(document.getElementById('Store-Name').value),
         crm: scrubBadJsonChar(document.querySelector('input#crm').value),
         area: scrubBadJsonChar(document.querySelector('input#systemArea').value),
         replicable: document.querySelector('[choice-selector][replicable-selector] .selected').getAttribute('replicable'),

--- a/src/common/testing/pageData/bugTicketData.js
+++ b/src/common/testing/pageData/bugTicketData.js
@@ -1,4 +1,6 @@
 export default async function setBugTicketData() {
+    document.getElementById('Support-Rep').value = 'Test Rep';
+    document.getElementById('Store-Name').value = 'Test Store';
     document.getElementById('crm').value = '6085';
     document.getElementById('systemArea').value = 'till';
     document.querySelector('[replicable="yes"]').click();


### PR DESCRIPTION
Added two new fields for Support Tech Name and Store Name. Simple validation at the moment that checks field isn't empty.
Added support for previous ticket being pulled from modal that don't have these fields don't break.
new tickets save new values for later pulling from modal history.