### PR TITLE
Add Trim to value updates

### DIFF
--- a/src/Tools/bug-ticket/validate-step-1.js
+++ b/src/Tools/bug-ticket/validate-step-1.js
@@ -206,28 +206,28 @@ export default {
             };
         },
         handleSupportRepUpdate(value) {
-            this.supportRep = value;
+            this.supportRep = value.trim();
         },
         handleStoreNameUpdate(value) {
-            this.storeName = value;
+            this.storeName = value.trim();
         },
         handleCRMUpdate(value) {
-            this.crm = value;
+            this.crm = value.trim();
         },
         handleDashboardURLUpdate(value) {
-            this.dashboardURL = value;
+            this.dashboardURL = value.trim();
         },
         handleRezoBrandUpdate(value) {
-            this.rezoBrand = value;
+            this.rezoBrand = value.trim();
         },
         handleSystemAreaUpdate(value) {
-            this.systemArea = value;
+            this.systemArea = value.trim();
         },
         handleReplicableUpdate(value) {
-            this.replicable = value;
+            this.replicable = value.trim();
         },
         handleWhereUpdate(value) {
-            this.where = value;
+            this.where = value.trim();
         },
     }
 }

--- a/src/Tools/bug-ticket/validate-step-2.js
+++ b/src/Tools/bug-ticket/validate-step-2.js
@@ -116,7 +116,7 @@ export default {
         },
         updateStep(index, value) {
             try {
-                this.steps[index] = value;
+                this.steps[index] = value.trim();
             } catch(error) {
                 console.error(`Error updating step`, error);
             }

--- a/src/Tools/bug-ticket/validate-step-3.js
+++ b/src/Tools/bug-ticket/validate-step-3.js
@@ -69,7 +69,7 @@ export default {
             };
         },
         updateDescription(value) {
-            this.description = value;
+            this.description = value.trim();
         },
     }
 }

--- a/src/Tools/bug-ticket/validate-step-4.js
+++ b/src/Tools/bug-ticket/validate-step-4.js
@@ -348,10 +348,10 @@ export default {
             }
         },
         updateScreenshotValue(index, value) {
-            this.screenshots[index] = value;
+            this.screenshots[index] = value.trim();
         },
         updateVideoValue(index, value) {
-            this.videos[index] = value;
+            this.videos[index] = value.trim();
         },
     },
 }

--- a/src/Tools/bug-ticket/validate-step-5.js
+++ b/src/Tools/bug-ticket/validate-step-5.js
@@ -70,10 +70,10 @@ export default {
     },
     methods: {
         updateExamplesValue(value) {
-            this.examplesValue = value;
+            this.examplesValue = value.trim();
         },
         updateErrorsValue(value) {
-            this.errorsValue = value;
+            this.errorsValue = value.trim();
         },
         async validate(returnData){
             let bad_data_list = {};


### PR DESCRIPTION
Support had an issue with validations throwing errors do to untrimmed values. I've updated the update value functions to trim the value being given so that they don't have trailing or leading spaces that could cause issues.